### PR TITLE
fix: Use Linux-based image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-# Use an official Python runtime as a parent image for Windows
-FROM python:3.10-windowsservercore
+# Use an official Python runtime as a parent image
+FROM python:3.10-slim
 
 # Set the working directory in the container
 WORKDIR /app
-
-# Set the default shell to PowerShell
-SHELL ["powershell", "-Command"]
 
 # Copy the requirements file and install dependencies
 COPY requirements.txt .


### PR DESCRIPTION
The Docker build was failing because the Dockerfile specified a Windows-based image (`python:3.10-windowsservercore`) while your CI environment runs on Linux.

This commit changes the base image to `python:3.10-slim` and removes the Windows-specific `SHELL` command to ensure the Docker image can be built successfully in the CI environment.